### PR TITLE
Fix: mutable image reference in action.yml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -89,12 +89,28 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+      - name: Pin release image tag
+        # Rewrites the image reference in action.yml from the mutable :edge tag
+        # to the exact version tag being released, then moves the git tag to
+        # point at the new commit so consumers always get a pinned image.
+        if: github.event_name == 'release'
+        run: |
+          VERSION="${{ github.event.release.tag_name }}"
+          IMAGE_TAG="${VERSION#v}"
+          sed -i "s|image: 'docker://ghcr.io/${{ env.ORG }}/${{ env.IMAGE_NAME }}:.*'|image: 'docker://ghcr.io/${{ env.ORG }}/${{ env.IMAGE_NAME }}:${IMAGE_TAG}'|" action.yml
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add action.yml
+          git commit -m "chore: pin action.yml image to ${VERSION}"
+          git push origin HEAD:main
+          git tag -f "${VERSION}"
+          git push origin -f "${VERSION}"
       # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
       - name: Update dependency graph
         uses: advanced-security/maven-dependency-submission-action@v5
         if: github.event_name != 'pull_request'
       - name: Create CBOM
-        uses: cbomkit/cbomkit-action@v2.2.0
+        uses: cbomkit/cbomkit-action@${{ github.ref_name }}
         id: cbom
           # Persist CBOM after a job has completed and share
           # that CBOM with another job in the same workflow.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -110,7 +110,7 @@ jobs:
         uses: advanced-security/maven-dependency-submission-action@v5
         if: github.event_name != 'pull_request'
       - name: Create CBOM
-        uses: cbomkit/cbomkit-action@${{ github.ref_name }}
+        uses: cbomkit/cbomkit-action@main
         id: cbom
           # Persist CBOM after a job has completed and share
           # that CBOM with another job in the same workflow.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,0 @@
-# Default tag is edge. This will be overritten for each release
-# and a dedicated release tag will be set.
-FROM ghcr.io/cbomkit/cbomkit-action:edge

--- a/action.yml
+++ b/action.yml
@@ -13,4 +13,4 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://ghcr.io/cbomkit/cbomkit-action:edge'

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.pqca</groupId>
             <artifactId>cbomkit-lib</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
### Summary
action.yml used image: 'Dockerfile', pointing at a wrapper that always pulled :edge. Every consumer ran whatever :edge resolved to on execution day, regardless of the pinned version tag. This is why v2.1.2 CI passed at tag time and broke months later with no commit in between.

### Fixes
#95 

### Changes
action.yml — replaced image: 'Dockerfile' with docker://ghcr.io/cbomkit/cbomkit-action:edge. The old Dockerfile wrapper is deleted.
build.yaml — new Pin release image tag step: on every release event, rewrites the image: line in action.yml to the exact semver tag, commits to main, and force-moves the git tag to that commit. Consumers pinning @vX.Y.Z now always get an immutable image. CBOM is always created with the latest version on main. 
build.yaml — Create CBOM self-reference updated from the hardcoded @v2.1.2 to @main so the repo always scans itself using the current main branch of the action.